### PR TITLE
Updated Audio Formats

### DIFF
--- a/setup-db.js
+++ b/setup-db.js
@@ -70,9 +70,12 @@ mongoClient.connect(function(err, client) {
                             "CD",
                             "VHS",
                             "Betamax",
-                            "Digital Tape",
+                            "DAT",
                             "Cassette",
-                            "Reel"
+                            "5_Reel",
+                            "7_Reel",
+                            "10_Reel",
+                            "Digital"
                         ],
                         description: "The type of medium the file was originally recorded to"
                     },


### PR DESCRIPTION
- Changed Digital Tape to DAT (Digital Audio Tape). That's the name of the format
- Changed reel to 3 different enums. 5_reel, 7_reel, 10_reel for the three sizes of reel-to-reels (5", 7", and 10.5") Are these file names acceptable
- Added digital as a format. Broadcasts 2002ish onwards are often recorded only in digital